### PR TITLE
Fix bug in contents reader (all sources being read for all origins)

### DIFF
--- a/src/ReaderDaemon.hs
+++ b/src/ReaderDaemon.hs
@@ -156,8 +156,8 @@ contentsReader pool user Mutexes{..} = do
             st <- Contents.readVaultObject lbl
             let d' = insertIntoDirectory d origin st
             liftIO $ putMVar directory d'
-            let flatten l m = (Map.keys m) ++ l
-            let sources = map createSourceResponse (Map.foldl flatten [] d')
+            let origin_sources o m = (Map.keys (Map.findWithDefault Map.empty o m))
+            let sources = map createSourceResponse (origin_sources origin d')
             let burst = encodeSourceResponseBurst (createSourceResponseBurst sources)
             liftIO $ writeChan contentsOut (Reply envelope client burst)
 


### PR DESCRIPTION
I apparently forgot to update the source-list-generation code when
moving to querying for contents on a per-origin basis.
