### PR TITLE
Expose Vaultaire.Types.Address

### DIFF
--- a/vaultaire.cabal
+++ b/vaultaire.cabal
@@ -33,13 +33,13 @@ library
                      Vaultaire.ReaderAlgorithms,
                      Vaultaire.InternalStore,
                      Vaultaire.ContentsServer,
+                     Vaultaire.Types.Address,
                      Marquise.Client,
                      Marquise.Server,
                      Marquise.Types,
                      Marquise.IO
 
   other-modules:     Vaultaire.Classes.WireFormat,
-                     Vaultaire.Types.Address,
                      Vaultaire.Types.ContentsOperation,
                      Vaultaire.Types.ContentsResponse,
                      Vaultaire.Types.SourceDict,


### PR DESCRIPTION
Since Sieste is also using the Address module, it makes sense to use it from Vaultaire. However, this module needs to be exposed in the vaultaire.cabal file for it to be usable. 
