### PR TITLE
Use configure time constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 *.prof
 *.mem
 *.hp
+src/Package.hs
 
 # real binaries
 bufferd

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ all: build
 #
 
 vault: dist/build/vault/vault
-marquised: dist/build/marquised/marquised
 demowave: dist/build/demowave/demowave
 reader-test: dist/build/reader-test/reader-test
 reader-algorithms: dist/build/reader-algorithms/reader-algorithms
@@ -47,7 +46,7 @@ test: dist/setup-config tags
 	@/bin/echo -e "CABAL\ttest"
 	cabal test
 
-dist/setup-config: vaultaire.cabal
+dist/setup-config: vaultaire.cabal Setup.hs
 	cabal configure \
 		--enable-tests \
 		--enable-benchmarks \
@@ -90,6 +89,7 @@ clean:
 	@/bin/echo -e "RM\ttemporary files"
 	-rm -f tags
 	-rm -f *.prof
+	-rm -f src/Package.hs
 
 doc:
 	cabal haddock

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,71 @@
+--
+-- Common Haskell build tools
+--
+-- Copyright © 2013-2014 Operational Dynamics Consulting, Pty Ltd and Others
+--
+-- The code in this file, and the program it is a part of, is
+-- made available to you by its authors as open source software:
+-- you can redistribute it and/or modify it under the terms of
+-- the 3-clause BSD licence.
+--
+
+import Data.Char (toUpper)
+import Distribution.Text (display)
+import Distribution.PackageDescription (PackageDescription(..))
 import Distribution.Simple
-main = defaultMain
+import Distribution.Simple.LocalBuildInfo (LocalBuildInfo)
+import Distribution.Simple.Setup (ConfigFlags)
+import Distribution.System (OS (..), buildOS)
+import System.IO (IOMode (..), Handle, hPutStrLn, withFile)
+
+main :: IO ()
+main = defaultMainWithHooks $ simpleUserHooks {
+       postConf = configure
+    }
+
+{-
+    Simple detection of which operating system we're building on;
+    there's no need to link the Cabal logic into our library, so
+    we output to a .hs file in src/
+-}
+
+configure :: Args -> ConfigFlags -> PackageDescription -> LocalBuildInfo -> IO ()
+configure _ _ p _  = do
+    withFile "src/Package.hs" WriteMode (\h -> do
+        outputModuleHeader h
+        discoverOperatingSystem h
+        discoverProgramVersion h p)
+
+    return ()
+
+outputModuleHeader :: Handle -> IO ()
+outputModuleHeader h = do
+    hPutStrLn h "module Package where"
+
+discoverOperatingSystem :: Handle -> IO ()
+discoverOperatingSystem h = do
+    hPutStrLn h "build :: String"
+    hPutStrLn h ("build = \"" ++ s ++ "\"")
+  where
+    o = buildOS
+
+    s = case o of
+            Linux   -> "Linux"
+            OSX     -> "Mac OS X"
+            Windows -> "Windows"
+            _       -> up o
+
+    up x = map toUpper (show x)
+
+discoverProgramVersion :: Handle -> PackageDescription -> IO ()
+discoverProgramVersion h p = do
+    hPutStrLn h "package :: String"
+    hPutStrLn h ("package = \"" ++ n ++ "\"")
+    hPutStrLn h "version :: String"
+    hPutStrLn h ("version = \"" ++ s ++ "\"")
+  where
+    i = package p
+    (PackageName n) = pkgName i
+    v = pkgVersion i
+    s = display v
+

--- a/src/DaemonRunners.hs
+++ b/src/DaemonRunners.hs
@@ -91,6 +91,6 @@ runContentsDaemon pool user broker shutdown =
 
 -- | Convenience wrapper around Marquise.Server
 runMarquiseDaemon :: String -> Origin -> String -> MVar () -> IO ()
-runMarquiseDaemon broker origin namespace _ = do
-    forkThread $ marquiseServer broker origin namespace
+runMarquiseDaemon broker origin namespace shutdown = do
+    forkThread $ marquiseServer broker origin namespace shutdown
 

--- a/src/Vault.hs
+++ b/src/Vault.hs
@@ -29,6 +29,7 @@ import Text.Trifecta
 import CommandRunners
 import DaemonRunners
 import Marquise.Client
+import Package (package, version)
 import Vaultaire.Program
 
 
@@ -280,7 +281,7 @@ main = do
             then Quiet
             else Normal
 
-    quit <- initializeProgram "vaultaire 2.1.0" level
+    quit <- initializeProgram (package ++ "-" ++ version) level
 
     -- Run daemons and/or commands. These are all expected to fork threads and
     -- return. If termination is requested, then they have to put unit into the

--- a/vaultaire.cabal
+++ b/vaultaire.cabal
@@ -10,7 +10,7 @@ category:            Other
 tested-with:         GHC == 7.6
 stability:           experimental
 
-build-type:          Simple
+build-type:          Custom
 
 source-repository    head
   type:              git


### PR DESCRIPTION
- Use custom Setup.hs to get make build-time constants available for debug messages.
