### PR TITLE
Employ TimeStamp newtype throughout

### DIFF
--- a/lib/Vaultaire/DayMap.hs
+++ b/lib/Vaultaire/DayMap.hs
@@ -3,7 +3,6 @@ module Vaultaire.DayMap
     DayMap(..),
     NumBuckets,
     Epoch,
-    Time,
     lookupFirst,
     lookupRange,
     loadDayMap
@@ -33,12 +32,12 @@ loadDayMap bs
             else Left "bad first entry, must start at zero."
 
 
-lookupFirst :: Time -> DayMap -> (Epoch, NumBuckets)
+lookupFirst :: TimeStamp -> DayMap -> (Epoch, NumBuckets)
 lookupFirst = (fst .) . splitRemainder
 
 -- Return first and the remainder that is later than that.
-splitRemainder :: Time -> DayMap -> ((Epoch, NumBuckets), DayMap)
-splitRemainder t (DayMap m) =
+splitRemainder :: TimeStamp -> DayMap -> ((Epoch, NumBuckets), DayMap)
+splitRemainder (TimeStamp t) (DayMap m) =
     let (left, middle, right) = Map.splitLookup t m
         first = case middle of
             Just n -> if Map.null left -- Corner case, leftmost entry
@@ -47,8 +46,8 @@ splitRemainder t (DayMap m) =
             Nothing -> Map.findMax left
     in (first, DayMap right)
 
-lookupRange :: Time -> Time -> DayMap -> [(Epoch, NumBuckets)]
-lookupRange start end dm =
+lookupRange :: TimeStamp -> TimeStamp -> DayMap -> [(Epoch, NumBuckets)]
+lookupRange start (TimeStamp end) dm =
     let (first, (DayMap remainder)) = splitRemainder start dm
         (rest,_) = Map.split end remainder
     in first : Map.toList rest

--- a/lib/Vaultaire/Reader.hs
+++ b/lib/Vaultaire/Reader.hs
@@ -50,7 +50,7 @@ handleRequest (Message reply_f origin' payload') =
 yieldNotNull :: Monad m => ByteString -> Pipe i ByteString m ()
 yieldNotNull bs = unless (S.null bs) (yield bs)
 
-processSimple :: Address -> Time -> Time -> Origin -> ReplyF -> Daemon ()
+processSimple :: Address -> TimeStamp -> TimeStamp -> Origin -> ReplyF -> Daemon ()
 processSimple addr start end origin' reply_f = do
     refreshOriginDays origin'
     maybe_range <- withSimpleDayMap origin' (lookupRange start end)
@@ -61,7 +61,7 @@ processSimple addr start end origin' reply_f = do
                             (lift . reply_f . SimpleStream . SimpleBurst)
         Nothing -> reply_f InvalidReadOrigin
 
-readSimple :: Origin -> Address -> Time -> Time
+readSimple :: Origin -> Address -> TimeStamp -> TimeStamp
            -> Pipe (Epoch, NumBuckets) ByteString Daemon ()
 readSimple origin' addr start end = forever $ do
     (epoch, num_buckets) <- await
@@ -76,7 +76,7 @@ readSimple origin' addr start end = forever $ do
         Right unprocessed -> yieldNotNull $ runST $
             processBucket unprocessed addr start end
 
-processExtended :: Address -> Time -> Time -> Origin -> ReplyF -> Daemon ()
+processExtended :: Address -> TimeStamp -> TimeStamp -> Origin -> ReplyF -> Daemon ()
 processExtended addr start end origin' reply_f = do
     refreshOriginDays origin'
     maybe_range <- withExtendedDayMap origin' (lookupRange start end)
@@ -86,7 +86,7 @@ processExtended addr start end origin' reply_f = do
                             (lift . reply_f . ExtendedStream . ExtendedBurst)
         Nothing -> reply_f InvalidReadOrigin
 
-readExtended :: Origin -> Address -> Time -> Time
+readExtended :: Origin -> Address -> TimeStamp -> TimeStamp
              -> Pipe (Epoch, NumBuckets) ByteString Daemon ()
 readExtended origin addr start end = forever $ do
     (epoch, num_buckets) <- await

--- a/lib/Vaultaire/ReaderAlgorithms.hs
+++ b/lib/Vaultaire/ReaderAlgorithms.hs
@@ -32,7 +32,7 @@ import Foreign.Storable
 import Pipes
 import Prelude hiding (filter)
 
-import Vaultaire.Types (Address (..))
+import Vaultaire.Types
 
 data Point = Point { address :: !Word64
                    , time    :: !Word64
@@ -124,8 +124,8 @@ deDuplicateLast cmp input
 -- | Filter and de-duplicate a bucket in-place. The original bytestring will be
 -- garbage after completion.
 processBucket :: (PrimMonad m)
-              => ByteString -> Address -> Word64 -> Word64 -> m ByteString
-processBucket bucket (Address addr) start end = do
+              => ByteString -> Address -> TimeStamp -> TimeStamp -> m ByteString
+processBucket bucket (Address addr) (TimeStamp start) (TimeStamp end) = do
     let v  = byteStringToVector bucket
     let v' = V.filter (\p -> address p == addr && time p >= start && time p <= end) v
     mv <- V.thaw v'
@@ -137,7 +137,7 @@ processBucket bucket (Address addr) start end = do
 -- transfer.
 mergeSimpleExtended :: (PrimMonad m)
                     => ByteString -> ByteString
-                    -> Address -> Word64 -> Word64
+                    -> Address -> TimeStamp -> TimeStamp
                     -> m ByteString
 mergeSimpleExtended simple extended addr start end = do
     de_duped <- byteStringToVector `liftM` processBucket simple addr start end

--- a/lib/Vaultaire/RollOver.hs
+++ b/lib/Vaultaire/RollOver.hs
@@ -38,16 +38,16 @@ rollOverExtendedDay origin' =
 -- You should only call this once with the maximum time of whatever data set
 -- you are writing down. This should be done within the same lock as that
 -- write.
-updateSimpleLatest :: Origin -> Time -> Daemon ()
+updateSimpleLatest :: Origin -> TimeStamp -> Daemon ()
 updateSimpleLatest origin' = updateLatest (simpleLatestOID origin')
 
-updateExtendedLatest :: Origin -> Time -> Daemon ()
+updateExtendedLatest :: Origin -> TimeStamp -> Daemon ()
 updateExtendedLatest origin' = updateLatest (extendedLatestOID origin')
 
 -- Internal
 
-updateLatest :: ByteString -> Time -> Daemon ()
-updateLatest oid time = withExLock oid . liftPool $ do
+updateLatest :: ByteString -> TimeStamp -> Daemon ()
+updateLatest oid (TimeStamp time) = withExLock oid . liftPool $ do
     result <- runObject oid readFull
     case result of
         Right v           -> when (parse v < time) doWrite

--- a/lib/Vaultaire/Writer.hs
+++ b/lib/Vaultaire/Writer.hs
@@ -47,8 +47,8 @@ data BatchState = BatchState
     { simple         :: !(EpochMap (BucketMap Builder))
     , extended       :: !(EpochMap (BucketMap Builder))
     , pending        :: !(EpochMap (BucketMap (Word64, [Word64 -> Builder])))
-    , latestSimple   :: !Time
-    , latestExtended :: !Time
+    , latestSimple   :: !TimeStamp
+    , latestExtended :: !TimeStamp
     , dayMaps        :: !(DayMap, DayMap) -- Simple, extended
     , bucketSize     :: !Word64
     , start          :: !UTCTime
@@ -100,7 +100,7 @@ processBatch bucket_size (Message reply origin payload) = do
             reply OnDisk
 
 processPoints :: MonadState BatchState m
-              => Word64 -> ByteString -> (DayMap, DayMap) -> Origin -> Time -> Time -> m ()
+              => Word64 -> ByteString -> (DayMap, DayMap) -> Origin -> TimeStamp -> TimeStamp -> m ()
 processPoints offset message day_maps origin latest_simple latest_ext
     | fromIntegral offset >= BS.length message = modify (\s -> s{ latestSimple = latest_simple
                                                                 , latestExtended = latest_ext })
@@ -130,10 +130,10 @@ processPoints offset message day_maps origin latest_simple latest_ext
                        | otherwise            = latest_simple
                 processPoints (offset + 24) message day_maps origin t latest_ext
 
-parseMessageAt :: Word64 -> Unpacking (Address, Time, Payload)
+parseMessageAt :: Word64 -> Unpacking (Address, TimeStamp, Payload)
 parseMessageAt offset = do
     unpackSetPosition (fromIntegral offset)
-    (,,) <$> (Address <$> getWord64LE) <*> getWord64LE <*> getWord64LE
+    (,,) <$> (Address <$> getWord64LE) <*> (TimeStamp <$> getWord64LE) <*> getWord64LE
 
 
 getBytesAt :: Word64 -> Word64 -> Unpacking ByteString
@@ -155,8 +155,8 @@ appendSimple epoch bucket bytes = do
     put $ s { simple = simple' }
 
 appendExtended :: MonadState BatchState m
-               => Epoch -> Bucket -> Address -> Time -> Word64 -> ByteString -> m ()
-appendExtended epoch bucket (Address address) time len string = do
+               => Epoch -> Bucket -> Address -> TimeStamp -> Word64 -> ByteString -> m ()
+appendExtended epoch bucket (Address address) (TimeStamp time) len string = do
     s <- get
 
     -- First we write to the simple bucket, inserting a closure that will

--- a/src/CommandRunners.hs
+++ b/src/CommandRunners.hs
@@ -34,7 +34,7 @@ import Vaultaire.Daemon (dayMapsFromCeph, extendedDayOID, simpleDayOID,
 import Vaultaire.Types
 
 
-runReadPoints :: String -> Origin -> Address -> Word64 -> Word64 -> IO ()
+runReadPoints :: String -> Origin -> Address -> TimeStamp -> TimeStamp -> IO ()
 runReadPoints broker origin addr start end = do
     withReaderConnection broker $ \c ->
         runEffect $ for (readSimple addr start end origin c >-> decodeSimple)
@@ -59,8 +59,8 @@ runDumpDayMap pool user origin =  do
             putStrLn "Extended day map:"
             print extended
 
-runRegisterOrigin :: String -> String -> Origin -> Word64 -> Word64 -> Word64 -> Word64 -> IO ()
-runRegisterOrigin pool user origin buckets step begin end = do
+runRegisterOrigin :: String -> String -> Origin -> Word64 -> Word64 -> TimeStamp -> TimeStamp -> IO ()
+runRegisterOrigin pool user origin buckets step (TimeStamp begin) (TimeStamp end) = do
     let targets = [simpleDayOID origin, extendedDayOID origin]
     let user' = Just (S.pack user)
     let pool' = S.pack pool

--- a/src/Inspect.hs
+++ b/src/Inspect.hs
@@ -46,12 +46,12 @@ data Component =
                | RegisterOrigin { origin  :: Origin
                                 , buckets :: Word64
                                 , step    :: Word64
-                                , begin   :: Word64
-                                , end     :: Word64 }
+                                , start   :: TimeStamp
+                                , end     :: TimeStamp }
                | Read { origin  :: Origin
                       , address :: Address
-                      , start   :: Word64
-                      , end     :: Word64 }
+                      , start   :: TimeStamp
+                      , end     :: TimeStamp }
                | List { origin :: Origin }
                | DumpDays { origin :: Origin }
 

--- a/tests/ReaderAlgorithms.hs
+++ b/tests/ReaderAlgorithms.hs
@@ -15,16 +15,15 @@ import Data.Vector.Generic.Mutable (MVector)
 import Data.Vector.Storable (Vector)
 import qualified Data.Vector.Storable as V
 import Data.Vector.Storable.ByteString
-import Data.Word
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck.Arbitrary
 import Test.QuickCheck.Gen
 import Vaultaire.ReaderAlgorithms (Point (..))
 import qualified Vaultaire.ReaderAlgorithms as A
-import Vaultaire.Types (Address (..))
+import Vaultaire.Types
 
-data AddrStartEnd = AddrStartEnd Address Word64 Word64
+data AddrStartEnd = AddrStartEnd Address TimeStamp TimeStamp
   deriving Show
 
 instance Arbitrary AddrStartEnd where
@@ -109,10 +108,10 @@ propNoDuplicates f v =
 
 propFilterNoLater :: AddrStartEnd -> Vector Point -> Bool
 propFilterNoLater (AddrStartEnd addr start end) v =
-    let v' = byteStringToVector $ runST $ A.processBucket (vectorToByteString v)addr start end
-    in V.null $ V.filter ((> end) . A.time) v'
+    let v' = byteStringToVector $ runST $ A.processBucket (vectorToByteString v) addr start end
+    in V.null $ V.filter ((> end) . TimeStamp . A.time) v'
 
 propFilterNoEarlier :: AddrStartEnd -> Vector Point -> Bool
 propFilterNoEarlier (AddrStartEnd addr start end) v =
     let v' = byteStringToVector $ runST $ A.processBucket (vectorToByteString v) addr start end
-    in V.null $ V.filter ((< start) . A.time) v'
+    in V.null $ V.filter ((< start) . TimeStamp . A.time) v'

--- a/vaultaire.cabal
+++ b/vaultaire.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                vaultaire
-version:             2.1.1
+version:             2.4.1
 synopsis:            Data vault for metrics
 license:             BSD3
 author:              Anchor Engineering <engineering@anchor.com.au>
@@ -52,7 +52,7 @@ library
                      stm,
                      semigroups,
                      hslogger >= 1.2.4,
-                     vaultaire-common >= 2.1.0,
+                     vaultaire-common >= 2.4.1,
                      text,
                      rados-haskell >= 3.0.3
 
@@ -77,9 +77,9 @@ executable vault
                      optparse-applicative,
                      trifecta >= 1.4.3,
                      directory,
-                     marquise >= 2.1.0,
+                     marquise >= 2.4.1,
                      containers,
-                     vaultaire-common >= 2.1.0,
+                     vaultaire-common >= 2.4.1,
                      pipes,
                      hslogger >= 1.2.4,
                      async,
@@ -106,9 +106,9 @@ executable inspect
                      optparse-applicative,
                      trifecta >= 1.4.3,
                      directory,
-                     marquise >= 2.1.0,
+                     marquise >= 2.4.1,
                      containers,
-                     vaultaire-common >= 2.1.0,
+                     vaultaire-common >= 2.4.1,
                      pipes,
                      hslogger >= 1.2.4,
                      async,


### PR DESCRIPTION
Final part of adopting the new-no-actually-old TimeStamp newtype across the codebase. Depends on https://github.com/anchor/marquise/pull/16 (pending) and https://github.com/anchor/vaultaire-common/pull/9 (merged).

AfC
