### PR TITLE
Restore linking Daemon Asyncs

### DIFF
--- a/src/DaemonRunners.hs
+++ b/src/DaemonRunners.hs
@@ -43,7 +43,7 @@ import Vaultaire.Writer (startWriter)
 forkThread :: IO a -> IO (Async a)
 forkThread action = do
     a <- async action
---  link a
+    link a
     return a
 
 


### PR DESCRIPTION
Link daemon threads to thread that spawned them, such that uncaught
exceptions propegate as opposed to dying silently.

Superseds and closes #49.
