### PR TITLE
Use SIGKILL rather than SIGABRT in watchdog

### DIFF
--- a/lib/Vaultaire/Daemon.hs
+++ b/lib/Vaultaire/Daemon.hs
@@ -299,8 +299,8 @@ wrapPool pool_action (Daemon r) = do
     watchdog :: IO ()
     watchdog = do
         threadDelay $ timeout * milliseconds
-        liftIO $ criticalM "Daemon.watchdog" "WATCHDOG TIMER ELAPSED"
-        raiseSignal sigABRT -- or KILL, depending on zmq
+        criticalM "Daemon.watchdog" "WATCHDOG TIMER ELAPSED"
+        raiseSignal sigKILL
 
 
 

--- a/vaultaire.cabal
+++ b/vaultaire.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                vaultaire
-version:             2.5.3
+version:             2.5.4
 synopsis:            Data vault for metrics
 license:             BSD3
 author:              Anchor Engineering <engineering@anchor.com.au>


### PR DESCRIPTION
Previous testing showed that SIGABRT did the trick, but that was on console. Running under docker seems to be interfering. Whatever; switch to SIGKILL as alternatively intended.

AfC
