### PR TITLE
Use median for telemtric latencies

### DIFF
--- a/tests/TestHelpers.hs
+++ b/tests/TestHelpers.hs
@@ -37,7 +37,7 @@ import Network.URI
 import System.Rados.Monadic
 import System.ZMQ4.Monadic
 import Vaultaire.Broker
-import Vaultaire.Daemon
+import Vaultaire.Daemon hiding (shutdown)
 import Vaultaire.Reader (startReader)
 import Vaultaire.RollOver
 import Vaultaire.Util


### PR DESCRIPTION
Please hold off merge.

This branch uses median instead of mean to give telemetric latencies.

The profiler is doing a little more work than with calculating the mean, and I'm not sure if we really need the median, or if the mean suffices. We'll see when trying to run this.
