### PR TITLE
Use raw origin for telemetry

### DIFF
--- a/lib/Vaultaire/InternalStore.hs
+++ b/lib/Vaultaire/InternalStore.hs
@@ -12,7 +12,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | This is a way for vaultaire components to store data within the Vault
--- itself.
+--   itself.
 module Vaultaire.InternalStore
 (
     writeTo,
@@ -83,6 +83,3 @@ enumerateOrigin origin =
         case buckets of
             Nothing -> return ()
             Just (s,e) -> mergeNoFilter s e
-
-namespace :: Origin -> Origin
-namespace = Origin . (`BS.append` "_INTERNAL") . unOrigin

--- a/lib/Vaultaire/InternalStore.hs
+++ b/lib/Vaultaire/InternalStore.hs
@@ -40,7 +40,7 @@ import Vaultaire.Writer (BatchState (..), appendExtended, write)
 -- | Given an origin and an address, write the given bytes.
 writeTo :: Origin -> Address -> ByteString -> Daemon ()
 writeTo origin addr payload =
-    write (namespace origin) False makeState
+    write True origin False makeState
   where
     makeState :: BatchState
     makeState =
@@ -79,7 +79,7 @@ enumerateOrigin origin =
         -- This is using the Reader so the profiled time is not exactly just
         -- Ceph waiting time, but also some reader checking.
         buckets <- lift $ profileTime ContentsEnumerateCeph origin
-                 $ getBuckets (namespace origin) 0 bucket
+                 $ getBuckets True origin 0 bucket
         case buckets of
             Nothing -> return ()
             Just (s,e) -> mergeNoFilter s e

--- a/lib/Vaultaire/InternalStore.hs
+++ b/lib/Vaultaire/InternalStore.hs
@@ -32,7 +32,7 @@ import Pipes
 import Pipes.Parse
 import qualified Pipes.Prelude as Pipes
 import Vaultaire.Daemon (Daemon, profileTime)
-import Vaultaire.Reader (getBuckets, readExtended)
+import Vaultaire.Reader (getBuckets, readExtendedInternal)
 import Vaultaire.ReaderAlgorithms (mergeNoFilter)
 import Vaultaire.Types
 import Vaultaire.Writer (BatchState (..), appendExtended, write)
@@ -59,7 +59,7 @@ internalStoreBuckets = 128
 readFrom :: Origin -> Address -> Daemon (Maybe ByteString)
 readFrom origin addr =
     evalStateT draw $ yield (0, internalStoreBuckets)
-                      >-> readExtended (namespace origin) addr 0 0
+                      >-> readExtendedInternal origin addr 0 0
                       >-> Pipes.map extractPayload
   where
     extractPayload bs = attemptUnpacking bs $ do

--- a/lib/Vaultaire/InternalStore.hs
+++ b/lib/Vaultaire/InternalStore.hs
@@ -18,7 +18,7 @@ module Vaultaire.InternalStore
     writeTo,
     readFrom,
     enumerateOrigin,
-    internalStoreBuckets,
+    internalStoreBuckets
 ) where
 
 import Control.Monad.State.Strict
@@ -32,6 +32,7 @@ import Pipes
 import Pipes.Parse
 import qualified Pipes.Prelude as Pipes
 import Vaultaire.Daemon (Daemon, profileTime)
+import Vaultaire.Origin
 import Vaultaire.Reader (getBuckets, readExtendedInternal)
 import Vaultaire.ReaderAlgorithms (mergeNoFilter)
 import Vaultaire.Types
@@ -40,7 +41,7 @@ import Vaultaire.Writer (BatchState (..), appendExtended, write)
 -- | Given an origin and an address, write the given bytes.
 writeTo :: Origin -> Address -> ByteString -> Daemon ()
 writeTo origin addr payload =
-    write True origin False makeState
+    write Internal origin False makeState
   where
     makeState :: BatchState
     makeState =
@@ -79,7 +80,7 @@ enumerateOrigin origin =
         -- This is using the Reader so the profiled time is not exactly just
         -- Ceph waiting time, but also some reader checking.
         buckets <- lift $ profileTime ContentsEnumerateCeph origin
-                 $ getBuckets True origin 0 bucket
+                 $ getBuckets Internal origin 0 bucket
         case buckets of
             Nothing -> return ()
             Just (s,e) -> mergeNoFilter s e

--- a/lib/Vaultaire/Origin.hs
+++ b/lib/Vaultaire/Origin.hs
@@ -1,8 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+{-|
+Low-level origin-related definitions which should not be exposed to
+clients (and therefore don't belong in Vaultaire.Types).
+-}
 module Vaultaire.Origin
 (
-    namespaceOrigin
+    namespaceOrigin,
+    Namespace(..)
 ) where
 
 import Data.ByteString (ByteString)
@@ -11,8 +16,7 @@ import qualified Data.ByteString.Char8 as BS
 import Vaultaire.Types
 
 -- | Suffix appended to the origin segment of a bucket name to indicate
---   that it's for internal use, e.g., for metadata buckets read/written
---   by the contents daemon.
+--   that it's for internal use.
 internalNamespace :: ByteString
 internalNamespace = "_INTERNAL"
 
@@ -20,8 +24,15 @@ internalNamespace = "_INTERNAL"
 --   the desired operation is on an internal bucket, the origin is
 --   qualified with the appropriate suffix; if not, it is returned
 --   unmodified.
-namespaceOrigin :: Bool   -- ^ Is the operation internal?
+namespaceOrigin :: Namespace  -- ^ Is the operation internal or external?
+                -> Origin     -- ^ Base origin (of the form returned by
+                              --   'makeOrigin')
                 -> Origin
-                -> Origin
-namespaceOrigin True = Origin . (`BS.append` internalNamespace) . unOrigin
-namespaceOrigin False = id
+namespaceOrigin Internal = Origin . (`BS.append` internalNamespace) . unOrigin
+namespaceOrigin External = id
+
+-- | An origin has both Internal and External buckets. Regular
+--   simple and extended points written by clients go in External
+--   buckets; Internal buckets are not directly accessible by clients
+--   and are used under the hood to store metadata.
+data Namespace = Internal | External

--- a/lib/Vaultaire/Origin.hs
+++ b/lib/Vaultaire/Origin.hs
@@ -10,11 +10,11 @@ import qualified Data.ByteString.Char8 as BS
 
 import Vaultaire.Types
 
+-- | Suffix appended to the origin segment of a bucket name to indicate
+--   that it's for internal use, e.g., for metadata buckets read/written
+--   by the contents daemon.
 internalNamespace :: ByteString
 internalNamespace = "_INTERNAL"
-
-internalOrigin :: Origin -> Origin
-internalOrigin = Origin . (`BS.append` internalNamespace) . unOrigin
 
 -- | Convert a raw origin to the raw origin used as a bucket prefix. If
 --   the desired operation is on an internal bucket, the origin is
@@ -23,5 +23,5 @@ internalOrigin = Origin . (`BS.append` internalNamespace) . unOrigin
 namespaceOrigin :: Bool   -- ^ Is the operation internal?
                 -> Origin
                 -> Origin
-namespaceOrigin True = internalOrigin
+namespaceOrigin True = Origin . (`BS.append` internalNamespace) . unOrigin
 namespaceOrigin False = id

--- a/lib/Vaultaire/Origin.hs
+++ b/lib/Vaultaire/Origin.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Vaultaire.Origin
+(
+    namespaceOrigin
+) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BS
+
+import Vaultaire.Types
+
+internalNamespace :: ByteString
+internalNamespace = "_INTERNAL"
+
+internalOrigin :: Origin -> Origin
+internalOrigin = Origin . (`BS.append` internalNamespace) . unOrigin
+
+-- | Convert a raw origin to the raw origin used as a bucket prefix. If
+--   the desired operation is on an internal bucket, the origin is
+--   qualified with the appropriate suffix; if not, it is returned
+--   unmodified.
+namespaceOrigin :: Bool   -- ^ Is the operation internal?
+                -> Origin
+                -> Origin
+namespaceOrigin True = internalOrigin
+namespaceOrigin False = id

--- a/lib/Vaultaire/Reader.hs
+++ b/lib/Vaultaire/Reader.hs
@@ -62,6 +62,9 @@ processSimple addr start end origin reply_f = do
                             (lift . reply_f . SimpleStream . SimpleBurst)
         Nothing -> reply_f InvalidReadOrigin
 
+-- | readSimple reads SimplePoints in a given time range from the vault.
+--   Cannot be used to read from internal (contents) buckets; regular
+--   time series only.
 readSimple :: Origin -> Address -> TimeStamp -> TimeStamp
            -> Pipe (Epoch, NumBuckets) ByteString Daemon ()
 readSimple origin addr start end = forever $ do
@@ -92,6 +95,8 @@ processExtended addr start end origin reply_f = do
                             (lift . reply_f . ExtendedStream . ExtendedBurst)
         Nothing -> reply_f InvalidReadOrigin
 
+-- | readExtended reads ExtendedPoints in a given time range. Cannot be
+--   used to read internal buckets.
 readExtended :: Origin -> Address -> TimeStamp -> TimeStamp
              -> Pipe (Epoch, NumBuckets) ByteString Daemon ()
 readExtended origin addr start end = forever $ do
@@ -105,8 +110,10 @@ readExtended origin addr start end = forever $ do
             lift $ profileCountN ReaderExtendedPoints origin (S.length bs `div` 24)
             yieldNotNull bs
 
--- | Retrieve simple and extended buckets in parallel
-getBuckets :: Bool
+-- | Retrieve simple and extended buckets in parallel. Can be used for
+--   either regular or internal buckets (controlled by the 'internal'
+--   flag).
+getBuckets :: Bool   -- ^ Is the bucket internal?
            -> Origin
            -> Epoch
            -> Bucket

--- a/lib/Vaultaire/Writer.hs
+++ b/lib/Vaultaire/Writer.hs
@@ -37,6 +37,7 @@ import System.Rados.Monadic hiding (async)
 import Text.Printf
 import Vaultaire.Daemon
 import Vaultaire.DayMap
+import Vaultaire.Origin
 import Vaultaire.RollOver
 import Vaultaire.Types
 import Vaultaire.Util (fatal)
@@ -65,7 +66,9 @@ batchStateNow :: BucketSize -> (DayMap, DayMap) -> IO BatchState
 batchStateNow bucket_size dms =
     BatchState mempty mempty mempty 0 0 dms bucket_size <$> getCurrentTime
 
-processBatch :: BucketSize -> Message -> Daemon ()
+processBatch :: BucketSize
+             -> Message
+             -> Daemon ()
 processBatch bucket_size (Message reply origin payload)
   = profileTime  WriterRequestLatency origin $ do
     profileCount WriterRequest        origin
@@ -85,6 +88,7 @@ processBatch bucket_size (Message reply origin payload)
             Just dms -> do
                 -- Most messages simply need to be placed into the correct epoch
                 -- and bucket, extended ones are a little more complex in that they
+
                 -- have to be stored as an offset to a pending write to the
                 -- extended buckets.
 
@@ -103,7 +107,7 @@ processBatch bucket_size (Message reply origin payload)
         Just s -> do
             wt1 <- liftIO getCurrentTime
             profileTime  WriterCephLatency origin
-                       $ write origin True s
+                       $ write False origin True s
             wt2 <- liftIO getCurrentTime
             liftIO . (debugM "Writer.processBatch") $ concat [
                 "Wrote simple objects at ",
@@ -225,18 +229,19 @@ appendExtended epoch bucket (Address address) (TimeStamp time) len string = do
 --   2. Simple buckets are written to disk with the pending writes applied.
 --   3. Acks are sent
 --   4. Any rollovers are done
-write :: Origin -> Bool -> BatchState -> Daemon ()
-write origin do_rollovers s = do
-    extended_offsets <- writeExtendedBuckets
+write :: Bool -> Origin -> Bool -> BatchState -> Daemon ()
+write internal origin do_rollovers s = do
+    let namespaced_origin = namespaceOrigin internal origin
+    extended_offsets <- writeExtendedBuckets namespaced_origin
 
     let simple_buckets = applyOffsets extended_offsets (simple s) (pending s)
-    simple_offsets <- stepTwo simple_buckets
+    simple_offsets <- stepTwo simple_buckets namespaced_origin
 
     -- Update latest files after the writes have gone down to disk, in case
     -- something happens between now and sending all the acks.
     when do_rollovers $ do
-        updateSimpleLatest origin (latestSimple s)
-        updateExtendedLatest origin (latestExtended s)
+        updateSimpleLatest namespaced_origin (latestSimple s)
+        updateExtendedLatest namespaced_origin (latestExtended s)
 
     -- 4. Do any rollovers
     when do_rollovers $ do
@@ -244,16 +249,16 @@ write origin do_rollovers s = do
         -- We want to ensure that the rollover only happens if an offset is
         -- exceeded for the latest epoch, otherwise we get duplicate
         -- rollovers.
-        (simple_epoch, n_simple_buckets) <- getLatestEpoch withSimpleDayMap
-        (extended_epoch, n_extended_buckets) <- getLatestEpoch withExtendedDayMap
+        (simple_epoch, n_simple_buckets) <- getLatestEpoch withSimpleDayMap namespaced_origin
+        (extended_epoch, n_extended_buckets) <- getLatestEpoch withExtendedDayMap namespaced_origin
 
         when (offsetExceeded simple_offsets simple_epoch limit)
-                (rollOverSimpleDay origin n_simple_buckets)
+                (rollOverSimpleDay namespaced_origin n_simple_buckets)
         when (offsetExceeded extended_offsets extended_epoch limit)
-                 (rollOverExtendedDay origin n_extended_buckets)
+                 (rollOverExtendedDay namespaced_origin n_extended_buckets)
   where
-    getLatestEpoch f =
-        f origin (lookupFirst maxBound) >>= mustBucket
+    getLatestEpoch f o =
+        f o (lookupFirst maxBound) >>= mustBucket
 
     mustBucket = maybe (error "could not find n_buckets for roll over") return
 
@@ -268,15 +273,15 @@ write origin do_rollovers s = do
 
     -- 1. Write extended buckets. We lock the entire origin for write as we
     -- will be operating on most buckets most of the time.
-    writeExtendedBuckets =
-        withLockExclusive (writeLockOID origin) $ liftPool $ do
+    writeExtendedBuckets o =
+        withLockExclusive (writeLockOID o) $ liftPool $ do
             -- First pass to get current offsets
             offsets <- forWithKey (extended s) $ \epoch buckets -> do
 
                 -- Make requests for the entire epoch
                 liftIO $ debugM "Writer.writeExtendedBuckets" "Stat extended objects"
                 stats <- forWithKey buckets $ \bucket _ ->
-                    extendedOffset origin epoch bucket
+                    extendedOffset o epoch bucket
 
                 -- Then extract the fileSize from those requests
                 for stats $ \async_stat -> do
@@ -295,7 +300,7 @@ write origin do_rollovers s = do
                 liftIO $ debugM "Writer.writeExtendedBuckets" "Write extended objects"
                 writes <- forWithKey buckets $ \bucket builder -> do
                     let payload = toStrict $ toLazyByteString builder
-                    writeExtended origin epoch bucket payload
+                    writeExtended o epoch bucket payload
 
                 for writes $ \async_write -> do
                     result <- waitSafe async_write
@@ -327,12 +332,12 @@ write origin do_rollovers s = do
                     in HashMap.insert epoch simple_buckets' simple_map''
 
     -- Final write,
-    stepTwo simple_buckets = liftPool $
+    stepTwo simple_buckets o = liftPool $
         forWithKey simple_buckets $ \epoch buckets -> do
             liftIO $ debugM "Writer.stepTwo" "Write simple objects"
             writes <- forWithKey buckets $ \bucket builder -> do
                 let payload = toStrict $ toLazyByteString builder
-                writeSimple origin epoch bucket payload
+                writeSimple o epoch bucket payload
             for writes $ \(async_stat, async_write) -> do
                 w <- waitSafe async_write
                 case w of

--- a/lib/Vaultaire/Writer.hs
+++ b/lib/Vaultaire/Writer.hs
@@ -90,7 +90,6 @@ processBatch bucket_size (Message reply origin payload)
             Just dms -> do
                 -- Most messages simply need to be placed into the correct epoch
                 -- and bucket, extended ones are a little more complex in that they
-
                 -- have to be stored as an offset to a pending write to the
                 -- extended buckets.
 

--- a/lib/Vaultaire/Writer.hs
+++ b/lib/Vaultaire/Writer.hs
@@ -66,6 +66,8 @@ batchStateNow :: BucketSize -> (DayMap, DayMap) -> IO BatchState
 batchStateNow bucket_size dms =
     BatchState mempty mempty mempty 0 0 dms bucket_size <$> getCurrentTime
 
+-- | Writes a batch of points. Will only write to regular
+--   (non-internal) buckets.
 processBatch :: BucketSize
              -> Message
              -> Daemon ()
@@ -229,7 +231,14 @@ appendExtended epoch bucket (Address address) (TimeStamp time) len string = do
 --   2. Simple buckets are written to disk with the pending writes applied.
 --   3. Acks are sent
 --   4. Any rollovers are done
-write :: Bool -> Origin -> Bool -> BatchState -> Daemon ()
+--
+--   This function is used to write both internal and external buckets;
+--   this is controlled by the first parameter.
+write :: Bool       -- ^ Is the bucket internal?
+      -> Origin
+      -> Bool
+      -> BatchState
+      -> Daemon ()
 write internal origin do_rollovers s = do
     let namespaced_origin = namespaceOrigin internal origin
     extended_offsets <- writeExtendedBuckets namespaced_origin

--- a/vaultaire.cabal
+++ b/vaultaire.cabal
@@ -28,6 +28,7 @@ library
                      Vaultaire.RollOver,
                      Vaultaire.Broker,
                      Vaultaire.DayMap,
+                     Vaultaire.Origin,
                      Vaultaire.OriginMap,
                      Vaultaire.Writer,
                      Vaultaire.Reader,


### PR DESCRIPTION
WIP, do not merge.

Fix bug in telemetry packing wherein the profiler is passed an origin
suffixed with a namespace (e.g., ABCDEF_INTERNAL), which (being longer
than eight bytes) breaks the packer.

TODO:
 - update tests
 - documentation
 - consider adding a length constraint to the origin type to prevent accidents