### PR TITLE
Documentation and cleanup

### DIFF
--- a/lib/Vaultaire/Broker.hs
+++ b/lib/Vaultaire/Broker.hs
@@ -8,7 +8,7 @@ import System.ZMQ4.Monadic
 
 -- | Start a ZMQ proxy, capture is always a Pub socket.
 --
--- This should never return lest catastrophic failure.
+--   This should never return except in the case of catastrophic failure.
 startProxy :: (SocketType front_t, SocketType back_t)
            => (front_t, String) -- ^ Frontend, clients
            -> (back_t, String)  -- ^ Backend, workers

--- a/lib/Vaultaire/Daemon.hs
+++ b/lib/Vaultaire/Daemon.hs
@@ -263,9 +263,11 @@ refreshOriginDays origin' = do
     Lock management
 -}
 
+-- | Lock timeout period, in seconds.
 timeout :: Int
 timeout = 600 -- 10 minutes
 
+-- | Duration of lock, in seconds.
 release :: Double
 release = fromIntegral $ timeout + 5
 
@@ -390,12 +392,15 @@ dayMapsFromCeph origin' = do
         Right day_map ->
             return $ Right (fromIntegral (BS.length contents), day_map)
 
+-- | Ceph object ID of the origin's Simple DayMap.
 simpleDayOID :: Origin -> ByteString
 simpleDayOID (Origin origin') = "02_" `BS.append` origin' `BS.append` "_simple_days"
 
+-- | Ceph object ID of the origin's Extended DayMap.
 extendedDayOID :: Origin -> ByteString
 extendedDayOID (Origin origin') = "02_" `BS.append` origin' `BS.append` "_extended_days"
 
+-- | Ceph object ID of the bucket at the provided epoch.
 bucketOID :: Origin -> Epoch -> Bucket -> String -> ByteString
 bucketOID (Origin origin') epoch bucket kind = BS.pack $ printf "02_%s_%020d_%020d_%s"
                                                          (BS.unpack origin')

--- a/lib/Vaultaire/Daemon.hs
+++ b/lib/Vaultaire/Daemon.hs
@@ -394,11 +394,11 @@ dayMapsFromCeph origin' = do
 
 -- | Ceph object ID of the origin's Simple DayMap.
 simpleDayOID :: Origin -> ByteString
-simpleDayOID (Origin origin') = "02_" `BS.append` origin' `BS.append` "_simple_days"
+simpleDayOID (Origin origin') = "02_" <> origin' <> "_simple_days"
 
 -- | Ceph object ID of the origin's Extended DayMap.
 extendedDayOID :: Origin -> ByteString
-extendedDayOID (Origin origin') = "02_" `BS.append` origin' `BS.append` "_extended_days"
+extendedDayOID (Origin origin') = "02_" <> origin' <> "_extended_days"
 
 -- | Ceph object ID of the bucket at the provided epoch.
 bucketOID :: Origin -> Epoch -> Bucket -> String -> ByteString

--- a/lib/Vaultaire/DayMap.hs
+++ b/lib/Vaultaire/DayMap.hs
@@ -38,7 +38,7 @@ lookupFirst :: TimeStamp -> DayMap -> (Epoch, NumBuckets)
 lookupFirst start dm = fst $ splitRemainder start dm
 
 -- | Return first entry and the remainder that is later than the provided
---   'TimeStamp'..
+--   'TimeStamp'.
 splitRemainder :: TimeStamp -> DayMap -> ((Epoch, NumBuckets), DayMap)
 splitRemainder (TimeStamp t) (DayMap m) =
     let (left, middle, right) = Map.splitLookup t m

--- a/lib/Vaultaire/DayMap.hs
+++ b/lib/Vaultaire/DayMap.hs
@@ -33,7 +33,7 @@ loadDayMap bs
 
 
 lookupFirst :: TimeStamp -> DayMap -> (Epoch, NumBuckets)
-lookupFirst = (fst .) . splitRemainder
+lookupFirst ts dm = fst $ splitRemainder ts dm
 
 -- Return first and the remainder that is later than that.
 splitRemainder :: TimeStamp -> DayMap -> ((Epoch, NumBuckets), DayMap)

--- a/lib/Vaultaire/DayMap.hs
+++ b/lib/Vaultaire/DayMap.hs
@@ -15,8 +15,9 @@ import qualified Data.Map as Map
 import Data.Packer
 import Vaultaire.Types
 
--- | Simple corruption check of input is done by checking that it is a multiple
--- of two Word64s
+-- | Parses a DayMap. Simple corruption check of input is done by
+--   checking that it is a multiple of two Word64s; Left is returned if
+--   corruption is detected, or if the provided ByteString is empty.
 loadDayMap :: ByteString -> Either String DayMap
 loadDayMap bs
     | BS.null bs =
@@ -31,11 +32,13 @@ loadDayMap bs
             then Right loaded
             else Left "bad first entry, must start at zero."
 
-
+-- | Finds the first entry in the provided 'DayMap' that's after the
+--   provided 'TimeStamp'.
 lookupFirst :: TimeStamp -> DayMap -> (Epoch, NumBuckets)
-lookupFirst ts dm = fst $ splitRemainder ts dm
+lookupFirst start dm = fst $ splitRemainder start dm
 
--- Return first and the remainder that is later than that.
+-- | Return first entry and the remainder that is later than the provided
+--   'TimeStamp'..
 splitRemainder :: TimeStamp -> DayMap -> ((Epoch, NumBuckets), DayMap)
 splitRemainder (TimeStamp t) (DayMap m) =
     let (left, middle, right) = Map.splitLookup t m
@@ -46,14 +49,18 @@ splitRemainder (TimeStamp t) (DayMap m) =
             Nothing -> Map.findMax left
     in (first, DayMap right)
 
+-- | Get the DayMap entries between two TimeStamps.
 lookupRange :: TimeStamp -> TimeStamp -> DayMap -> [(Epoch, NumBuckets)]
 lookupRange start (TimeStamp end) dm =
-    let (first, (DayMap remainder)) = splitRemainder start dm
+    let (first, DayMap remainder) = splitRemainder start dm
         (rest,_) = Map.split end remainder
     in first : Map.toList rest
 
 -- Internal
 
+-- | Unpack a ByteString consisting of one or more
+--   ('Epoch','NumBuckets') pairs into a 'DayMap'. Will throw an
+--   'OutOfBoundUnpacking' error on badly-formed data.
 mustLoadDayMap :: ByteString -> DayMap
 mustLoadDayMap =
     DayMap . Map.fromList . runUnpacking parse

--- a/lib/Vaultaire/Profiler.hs
+++ b/lib/Vaultaire/Profiler.hs
@@ -58,6 +58,8 @@ runProfiler e (Profiler x) = do
     debugM "Profiler.runProfiler" "Profiler sealed and cleaned up."
     return r
 
+-- | Runs the profiling loop which reads reports from the worker and
+--   publishes them via ZeroMQ.
 startProfiler :: ProfilingEnv -> IO ()
 startProfiler env@(ProfilingEnv{..}) =
     Z.withContext $ \ctx ->
@@ -71,10 +73,14 @@ data ProfilingInterface = ProfilingInterface
     { -- Reporting functions, they will perform the necessary measurements
       -- and send them to the profiler.
       profCount   :: MonadIO m => TeleMsgType -> Origin -> Int -> m ()
+      -- ^ Queue sending a count profiling message.
     , profTime    :: MonadIO m => TeleMsgType -> Origin -> m r -> m r
+      -- ^ Report the time taken by an action.
       -- Raw measurement and sending functions.
     , measureTime :: MonadIO m => m r -> m (r, Word64)
+      -- ^ Measure the time elapsed for the provided action (in ms).
     , report      :: MonadIO m => TeleMsgType -> Origin -> Word64 -> m () }
+      -- ^ Send a profiling report to be queued.
 
 -- | Arguments needed to be specified by the user for profiling
 --   (name, publishing port, period, bound, shutdown signal).

--- a/lib/Vaultaire/RollOver.hs
+++ b/lib/Vaultaire/RollOver.hs
@@ -20,32 +20,36 @@ import Vaultaire.DayMap
 import Vaultaire.Types
 
 -- | Roll the cluster onto a new "vault day", this will block until all other
--- daemons are synchronized at acquiring any shared locks.
+--   daemons are synchronized at acquiring any shared locks.
 --
--- All day maps will be invalidated on roll over, it is up to you to ensure
--- that they are reloaded before next use.
+--   All day maps will be invalidated on roll over, it is up to you to ensure
+--   that they are reloaded before next use.
 rollOverSimpleDay :: Origin -> NumBuckets -> Daemon ()
 rollOverSimpleDay origin' =
     rollOver origin' (simpleDayOID origin') (simpleLatestOID origin')
 
+-- | Equivalent of 'rollOverSimpleDay' for extended buckets.
 rollOverExtendedDay :: Origin -> NumBuckets -> Daemon ()
 rollOverExtendedDay origin' =
     rollOver origin' (extendedDayOID origin') (extendedLatestOID origin')
 
 -- | This compares the given time against the latest one in ceph, and updates
--- if larger.
+--   if larger.
 --
--- You should only call this once with the maximum time of whatever data set
--- you are writing down. This should be done within the same lock as that
--- write.
+--   You should only call this once with the maximum time of whatever data set
+--   you are writing down. This should be done within the same lock as that
+--   write.
 updateSimpleLatest :: Origin -> TimeStamp -> Daemon ()
 updateSimpleLatest origin' = updateLatest (simpleLatestOID origin')
 
+-- | Equivalent of 'updateSimpleLatest' for extended buckets.
 updateExtendedLatest :: Origin -> TimeStamp -> Daemon ()
 updateExtendedLatest origin' = updateLatest (extendedLatestOID origin')
 
 -- Internal
 
+-- | Updates the latest time specified Ceph object to the provided
+--   'TimeStamp', if it is later than the one the object already has.
 updateLatest :: ByteString -> TimeStamp -> Daemon ()
 updateLatest oid (TimeStamp time) = withLockExclusive oid . liftPool $ do
     result <- runObject oid readFull

--- a/lib/Vaultaire/RollOver.hs
+++ b/lib/Vaultaire/RollOver.hs
@@ -93,14 +93,15 @@ rollOver origin day_file latest_file buckets =
 originLockOID :: Origin -> ByteString
 originLockOID = simpleLatestOID
 
--- | Construct the ID of the Ceph object storing the timestamp of the
---   latest 'SimplePoint' written to an origin.
+-- | Construct the ID of the Ceph object storing the time at which the
+--   latest 'SimplePoint' was written to an origin (note that this is
+--   the time at which the point was written, *not* the timestamp of the
+--   point itself).
 simpleLatestOID :: Origin -> ByteString
 simpleLatestOID (Origin origin') =
     "02_" <> origin' <> "_simple_latest"
 
--- | Construct the ID of the Ceph object storing the timestamp of the
---   latest 'ExtendedPoint' written to an origin.
+-- | Analogous to 'simpleLatestOID' for extended points.
 extendedLatestOID :: Origin -> ByteString
 extendedLatestOID (Origin origin') =
     "02_" <> origin' <> "_extended_latest"

--- a/lib/Vaultaire/RollOver.hs
+++ b/lib/Vaultaire/RollOver.hs
@@ -93,10 +93,9 @@ rollOver origin day_file latest_file buckets =
 originLockOID :: Origin -> ByteString
 originLockOID = simpleLatestOID
 
--- | Construct the ID of the Ceph object storing the time at which the
---   latest 'SimplePoint' was written to an origin (note that this is
---   the time at which the point was written, *not* the timestamp of the
---   point itself).
+-- | Construct the ID of the Ceph object storing the timestamp of the
+--   latest 'SimplePoint' which was written to an origin (note that this is
+--   the timestamp of the point, not the time at which it was written).
 simpleLatestOID :: Origin -> ByteString
 simpleLatestOID (Origin origin') =
     "02_" <> origin' <> "_simple_latest"

--- a/lib/Vaultaire/RollOver.hs
+++ b/lib/Vaultaire/RollOver.hs
@@ -13,6 +13,7 @@ module Vaultaire.RollOver
 import Control.Monad.State
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import Data.Monoid
 import Data.Packer
 import System.Rados.Monadic
 import Vaultaire.Daemon
@@ -76,7 +77,7 @@ rollOver origin day_file latest_file buckets =
                 error $ "corrupt latest file in origin': " ++ show origin
 
             app <- liftPool . runObject day_file $
-                append (latest `BS.append` build buckets)
+                append (latest <> build buckets)
 
             case app of
                 Just e  -> error $ "failed to append for rollover: " ++ show e
@@ -91,9 +92,9 @@ originLockOID = simpleLatestOID
 
 simpleLatestOID :: Origin -> ByteString
 simpleLatestOID (Origin origin') =
-    "02_" `BS.append` origin' `BS.append` "_simple_latest"
+    "02_" <> origin' <> "_simple_latest"
 
 extendedLatestOID :: Origin -> ByteString
 extendedLatestOID (Origin origin') =
-    "02_" `BS.append` origin' `BS.append` "_extended_latest"
+    "02_" <> origin' <> "_extended_latest"
 

--- a/lib/Vaultaire/Writer.hs
+++ b/lib/Vaultaire/Writer.hs
@@ -14,7 +14,6 @@ module Vaultaire.Writer
     write,
     batchStateNow,
     BatchState(..),
-    Event(..),
 ) where
 
 import Control.Applicative
@@ -56,8 +55,6 @@ data BatchState = BatchState
     , bucketSize     :: !Word64
     , start          :: !UTCTime
     }
-
-data Event = Msg Message | Tick
 
 -- | Start a writer daemon, runs until shutdown.
 startWriter :: DaemonArgs -> BucketSize -> IO ()

--- a/lib/Vaultaire/Writer.hs
+++ b/lib/Vaultaire/Writer.hs
@@ -393,4 +393,4 @@ writeSimple o e b payload =
 -- | Object ID of the write lock object for an origin.
 writeLockOID :: Origin -> ByteString
 writeLockOID (Origin o') =
-    "02_" `S.append` o' `S.append` "_write_lock"
+    "02_" <> o' <> "_write_lock"

--- a/tests/ContentsTest.hs
+++ b/tests/ContentsTest.hs
@@ -15,7 +15,7 @@
 
 module Main where
 
-import System.ZMQ4.Monadic hiding (Event)
+import System.ZMQ4.Monadic
 
 import Test.Hspec hiding (pending)
 

--- a/tests/ReaderTest.hs
+++ b/tests/ReaderTest.hs
@@ -7,7 +7,7 @@ import Control.Concurrent
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.List.NonEmpty (fromList)
-import System.ZMQ4.Monadic hiding (Event)
+import System.ZMQ4.Monadic
 import Test.Hspec hiding (pending)
 import TestHelpers
 

--- a/tests/WriterTest.hs
+++ b/tests/WriterTest.hs
@@ -16,7 +16,7 @@ import Data.Maybe
 import Data.Time
 import Network.URI
 import System.Rados.Monadic
-import System.ZMQ4.Monadic hiding (Event)
+import System.ZMQ4.Monadic
 import Test.Hspec hiding (pending)
 
 import TestHelpers


### PR DESCRIPTION
Going through and adding missing toplevel Haddock comments, rewriting any that seem terse or unclear, and fixing some minor style/formatting issues as I come across them.

The one nontrivial refactoring made is to remove the (exported) Event type, which is dead code with no remaining use. @christian-marie and I decided that it wouldn't be too terrible to cowboy this into a patch release at this stage of maturity, as the probability of anyone having used it is negligible.

The refactor involves replacing explicit ByteString.appends with mappends; any objections to that?