### PR TITLE
Add keyring option to vault program to set the CEPH_KEYRING envvar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## User interface
 
  * The `CEPH_KEYRING` environment variable no longer needs to be manually
-   specified; it can be passed in as the `--ceph-keyring` command-line
+   specified; it can be passed in as the `--keyring` command-line
    option to the `vault` program.
 
  * The unused `Event` type has been removed from the `Vaultaire.Writer`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## User interface
 
-The CEPH_KEYRING environment variable no longer needs to be manually
-specified; it can be passed in as the `--ceph-keyring` command-line
-option to the `vault` program.
+ * The `CEPH_KEYRING` environment variable no longer needs to be manually
+   specified; it can be passed in as the `--ceph-keyring` command-line
+   option to the `vault` program.
+
+ * The unused `Event` type has been removed from the `Vaultaire.Writer`
+   module.
 
 # 2.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
+# 2.6.2
+
+## User interface
+
+The CEPH_KEYRING environment variable no longer needs to be manually
+specified; it can be passed in as the `--ceph-keyring` command-line
+option to the `vault` program.
+
 # 2.6.1
 
 ## User interface
+
 To disable profiling, run ``vault --no-profiling``. By default,
 profiling is enabled with a period of 1s and an accuracy bound of 2048
 telemetric stats per second.

--- a/README.markdown
+++ b/README.markdown
@@ -80,9 +80,11 @@ you want to make the broker highly-available, use a TCP load-balancer).
 
 The defaults assume your Rados pool is called `vaultaire`, and you're
 connecting with the username `vaultaire`; if this isn't the case,
-override with `-p` and `-u` respectively. In either case, you'll need to
-have the environment variable `CEPH_KEYRING` pointing to the correct
-place.
+override with `-p` and `-u` respectively.
+
+Additionally, if your Ceph keyring is not at the default path used by
+librados (`/etc/ceph/keyring` as of Feburary 2015) you'll need to
+override it with `-k /path/to/your/keyring/file`.
 
 ```
 vault -d broker # Start broker in debug mode

--- a/src/Vault.hs
+++ b/src/Vault.hs
@@ -40,7 +40,7 @@ data Options = Options
   , period       :: Int
   , bound        :: Int
   , name         :: String
-  , ceph_keyring :: String
+  , keyring      :: String
   , component    :: Component }
 
 data Component = Broker
@@ -127,9 +127,9 @@ optionsParser Options{..} = Options <$> parsePool
         <> help "Identifiable name for the daemon. Useful for telemetrics."
 
     parseKeyring = strOption $
-           long "ceph-keyring"
+           long "keyring"
         <> short 'k'
-        <> metavar "CEPH-KEYRING"
+        <> metavar "KEYRING"
         <> value ""
         <> help "Path to Ceph keyring file. If set, this will override the CEPH_KEYRING environment variable."
 
@@ -190,7 +190,7 @@ parseConfig fp = do
                 <*> (join $ readMaybe <$> lookup "period" ls) `mplus` pure period
                 <*> (join $ readMaybe <$> lookup "bound" ls)  `mplus` pure period
                 <*> lookup "name" ls `mplus` pure name
-                <*> lookup "ceph_keyring" ls `mplus` pure ceph_keyring
+                <*> lookup "keyring" ls `mplus` pure keyring
                 <*> pure Broker
 
 configParser :: Parser [(String, String)]
@@ -224,7 +224,7 @@ main = do
               | quiet     = Quiet
               | otherwise = Normal
 
-    updateCephKeyring ceph_keyring
+    updateCephKeyring keyring
 
     quit <- initializeProgram (package ++ "-" ++ version) level
 

--- a/src/Vault.hs
+++ b/src/Vault.hs
@@ -178,8 +178,17 @@ parseConfig fp = do
                 Nothing  -> error "Failed to parse config"
         else return defaultConfig
   where
-    defaultConfig = Options "vaultaire" "vaultaire" "localhost"
-                            False False False 1000 2048 "" "" Broker
+    defaultConfig = Options "vaultaire" -- Use 'vaultaire' rados pool.
+                            "vaultaire" -- Connect as 'vaultaire' user.
+                            "localhost" -- Default to broker on localhost.
+                            False       -- Don't print debug output.
+                            False       -- Don't suppress all output.
+                            False       -- Don't disable profiling.
+                            1000        -- Write telemetry every 1000ms.
+                            2048        -- Handle <= 2048 telemetry reports per period.
+                            ""          -- Use a blank agent name for telemetry.
+                            ""          -- Don't set CEPH_KEYRING.
+                            Broker      -- Run in broker mode.
     mergeConfig ls Options{..} = fromJust $
         Options <$> lookup "pool" ls `mplus` pure pool
                 <*> lookup "user" ls `mplus` pure user

--- a/vaultaire.cabal
+++ b/vaultaire.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                vaultaire
-version:             2.6.1.4
+version:             2.6.2.0
 synopsis:            Data vault for metrics
 description:         Data vault for metrics
 license:             BSD3


### PR DESCRIPTION
So we don't have runtime behavior dependent on a mix of CLI options and
environment variables.

Fixes GitHub issue #79.