### PR TITLE
Default to hostname rather than empty string for agent ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## User interface
 
- * The `CEPH_KEYRING` environment variable no longer needs to be manually
+ - The `CEPH_KEYRING` environment variable no longer needs to be manually
    specified; it can be passed in as the `--keyring` command-line
    option to the `vault` program.
 
- * The unused `Event` type has been removed from the `Vaultaire.Writer`
+ - The unused `Event` type has been removed from the `Vaultaire.Writer`
    module.
+
+## Telemetry
+
+ - Default to hostname rather than empty string for the telemetry agent
+   ID.
 
 # 2.6.1
 
@@ -24,16 +29,16 @@ telemetric stats per second.
 To enable profiling when running `vault`, use the flag `'--profiling'`.
 Optionally, you can also specify:
 
-  * The profiling period with `-period <number of milliseconds>`.
-  * The name of the daemon, with `-n <name>`, for easy reading of
+  - The profiling period with `-period <number of milliseconds>`.
+  - The name of the daemon, with `-n <name>`, for easy reading of
     telemetric reports.
 
 ## Internal changes
 
-* The broker ``String`` is replaced by a ``URI`` type from the
-  ``network-uri`` package. It does validation and allows easy
-  manipulation of URI strings.
-* Most functions that previously take a broker string, a Ceph user, a
-  Ceph pool and a signal now take those things in a ``DaemonArgs`` sum
-  type, which also includes a profiling interface. Use the smart
-  constructor ``daemonArgs`` to create this sum type.
+ - The broker ``String`` is replaced by a ``URI`` type from the
+   ``network-uri`` package. It does validation and allows easy
+   manipulation of URI strings.
+ - Most functions that previously take a broker string, a Ceph user, a
+   Ceph pool and a signal now take those things in a ``DaemonArgs`` sum
+   type, which also includes a profiling interface. Use the smart
+   constructor ``daemonArgs`` to create this sum type.

--- a/vaultaire.cabal
+++ b/vaultaire.cabal
@@ -65,7 +65,7 @@ library
                      stm,
                      semigroups,
                      hslogger >= 1.2.4,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      text,
                      unix,
                      unix-time,
@@ -97,7 +97,7 @@ executable vault
                      directory,
                      marquise >= 3.0.2,
                      containers,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      pipes,
                      hslogger >= 1.2.4,
                      async,
@@ -130,7 +130,7 @@ executable inspect
                      directory,
                      marquise >= 3.0.2,
                      containers,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      pipes,
                      hslogger >= 1.2.4,
                      async,
@@ -159,7 +159,7 @@ executable demowave
                      directory,
                      marquise >= 3.0.2,
                      containers,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      pipes,
                      hslogger,
                      time,
@@ -185,7 +185,7 @@ executable telemetry
                      network-uri,
                      optparse-applicative >= 0.11.0,
                      zeromq4-haskell,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      vaultaire
 
   ghc-options:       -O2
@@ -209,7 +209,7 @@ test-suite           daemon-test
   build-depends:     base >=3 && <5,
                      hspec,
                      async,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      semigroups,
                      bytestring,
                      vaultaire,
@@ -254,7 +254,7 @@ test-suite           writer-test
                      pipes,
                      pipes-parse,
                      semigroups,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      zeromq4-haskell,
                      mtl,
                      bytestring,
@@ -287,7 +287,7 @@ test-suite           reader-test
                      pipes,
                      pipes-parse,
                      semigroups,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      zeromq4-haskell,
                      mtl,
                      bytestring,
@@ -313,7 +313,7 @@ test-suite           reader-algorithms-test
                      containers,
                      QuickCheck,
                      primitive,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      spool,
                      vector,
                      mtl,
@@ -348,7 +348,7 @@ test-suite           internal-store-test
                      locators >= 0.2.4,
                      pipes-parse,
                      mtl,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      bytestring,
                      zeromq4-haskell,
                      vaultaire
@@ -384,7 +384,7 @@ test-suite           contents-test
                      marquise >= 3.0.2,
                      bytestring,
                      zeromq4-haskell,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      pipes,
                      vaultaire
 
@@ -419,7 +419,7 @@ test-suite           integration-test
                      zeromq4-haskell,
                      rados-haskell >= 3.0.1,
                      directory,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      vaultaire
 
   ghc-options:       -O2
@@ -440,7 +440,7 @@ benchmark writer-bench
                      semigroups,
                      rados-haskell,
                      criterion,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      vaultaire
 
   ghc-options:       -O2
@@ -481,7 +481,7 @@ benchmark contents-listing
                      bytestring,
                      criterion,
                      zeromq4-haskell,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      marquise >= 2.8.3,
                      vaultaire
 
@@ -513,7 +513,7 @@ test-suite           profiler-test
                      rados-haskell >= 3.0.1,
                      mtl,
                      transformers,
-                     vaultaire-common >= 2.8.2,
+                     vaultaire-common >= 2.9,
                      vaultaire
 
   ghc-options:       -O2


### PR DESCRIPTION
So that the default case is less likely to produce a horrible mess of
aggregated telemetry streams.

Depends on #80 and anchor/vaultaire-common#33.